### PR TITLE
Fix scrolling for Firefox

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -33,7 +33,7 @@ var Docs = {
   },
 
   scrollSmooth: function() {
-    $(document.body).animate({
+    $('body, html').animate({
       scrollTop: $("#" + Docs.subsection).offset().top
     }, 500);
   }


### PR DESCRIPTION
Currently jump links in the docs are broken. By default, Firefox places the overflow at the HTML level unless explicitly defined. This pull request fixes the docs for both Firefox and webkit browsers.

@cazzo - Can you review/land this?
