### PR TITLE
Fix misleading example for map function

### DIFF
--- a/docs/firmware.md
+++ b/docs/firmware.md
@@ -1698,7 +1698,7 @@ void setup() {}
 void loop()
 {
   int val = analogRead(0);
-  val = map(val, 0, 1023, 0, 255);
+  val = map(val, 0, 4095, 0, 255);
   analogWrite(9, val);
 }
 ```


### PR DESCRIPTION
An example for map used map(val,0,1023,0,255) to map a value from an analogue pin to 0-255 (probably copied/pasted from arduino).  this is misleading because analog pins actually return 0-4095).  This pull request fixes that.  
