### PR TITLE
Networks with WEP security

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,7 +11,6 @@ There are known issues with the following types of networks:
 - **Networks with ["captive portal"](http://en.wikipedia.org/wiki/Captive_portal) security**. A captive portal is the little website that comes up to ask you to sign in to a network or sign an agreement, like at a Starbucks. The Spark Core can't navigate these portals.
 - **Enterprise networks**. We have had mixed results connecting the Spark Core to enterprise networks, although we don't yet have a great understanding of what's causing the issue. This is something that we are working to improve.
 - **Complex networks**. Networks with multiple routers, with non-standard firewalls, and with non-standard settings.
-- **Networks with WEP security**. If connecting with the mobile app works for you, WEP-secured networks should be fine. However, you cannot currently connect to a WEP-secured network over USB. We are implementing a fix for this now, which should be available in the next couple of weeks.
 - **Channels above 11**. This is in particular an international issue; if you are outside the U.S., your Wi-Fi router might run at channels 12, 13, or 14, which the CC3000 does not support. Please use channels numbered 11 or lower.
 
 So, let's dig in. If your Spark Core is not connecting to your Wi-Fi network, we recommend following these steps:


### PR DESCRIPTION
This is still valid?

Networks with WEP security. 
If connecting with the mobile app works for you, WEP-secured networks should be fine. However, you cannot currently connect to a WEP-secured network over USB. We are implementing a fix for this now, which should be available in the next couple of weeks.
