### PR TITLE
Removed 1 specification from Battery Shield

### DIFF
--- a/docs/shields.md
+++ b/docs/shields.md
@@ -289,6 +289,7 @@ Specifications
 - Simultaneously charge the battery and power the core
 - Dimensions: 2.3 x 0.61
 - Weight: 20g
+- Datasheet: [MCP73871](https://github.com/spark/shields/blob/master/Battery%20Shield/battery-shield-smallinductor/Datasheets/MCP73871.pdf) and [TPS61200](https://github.com/spark/shields/blob/master/Battery%20Shield/battery-shield-smallinductor/Datasheets/tps61200.pdf)
 
 
 Setting up the shield

--- a/docs/shields.md
+++ b/docs/shields.md
@@ -287,7 +287,6 @@ Specifications
 
 - Works with any 3.7V Lithium Polymer battery.
 - Simultaneously charge the battery and power the core
-- Provide link to the datasheets MCP73871 and TPS61200
 - Dimensions: 2.3 x 0.61
 - Weight: 20g
 


### PR DESCRIPTION
Not sure why 'Provide link to the datasheets MCP73871 and TPS61200' is under Specifications...
