### PR TITLE
expand code kerning a bit, fix issue with button text wrapping

### DIFF
--- a/src/stylesheets/content.less
+++ b/src/stylesheets/content.less
@@ -83,7 +83,7 @@
   background: transparent;
   font-size: 16px;
   line-height: 21px;
-  letter-spacing: -1px;
+  letter-spacing: -0.5px;
 }
 .content blockquote :first-child {
   padding-top: 0;
@@ -294,7 +294,6 @@ body.no-literate .content pre > code:hover::-webkit-scrollbar-thumb {
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   font-family: montserrat, sans-serif;
-  letter-spacing: -1px;
   font-weight: bold;
   display: inline-block;
   padding: 3px 25px;


### PR DESCRIPTION
Preformatted code looks better if it's expanded a bit, instead of all of the letters bunched up on top of each other.

Button text will wrap onto itself for some reason at different Browser zoom levels if the character kerning is -1.  Removing this hardly effects the look of the buttons, makes them more readable and fixing the wrapping issue.
