### PR TITLE
Update example to use Serial.write() since Serial.print(,BYTE) has been superseded

### DIFF
--- a/src/content/firmware.md
+++ b/src/content/firmware.md
@@ -757,13 +757,13 @@ void loop()
   if (Serial.available())
   {
     int inByte = Serial.read();
-    Serial1.print(inByte, BYTE);
+    Serial1.write(inByte);
   }
   // read from port 1, send to port 0:
   if (Serial1.available())
   {
     int inByte = Serial1.read();
-    Serial.print(inByte, BYTE);
+    Serial.write(inByte);
   }
 }
 ```


### PR DESCRIPTION
Serial.print(,BYTE) has been superseded and you should now use Serial.write()
