### PR TITLE
Limit on Spark variables is not per user

### DIFF
--- a/src/content/firmware.md
+++ b/src/content/firmware.md
@@ -40,7 +40,7 @@ void loop()
   Delay(200);
 }
 ```
-Currently, a user is allowed to define up to 10 Spark variables and each variable name is limited to a max of 12 characters.
+Currently, up to 10 Spark variables may be defined and each variable name is limited to a max of 12 characters.
 
 There are three supported data types:
 


### PR DESCRIPTION
If we say a user can define 10, it begs the question: 10 in total over all his Sparks? 10 concurrently in the Cloud per user account?
