### PR TITLE
Fix long access_token and core_id length

### DIFF
--- a/src/content/examples.md
+++ b/src/content/examples.md
@@ -147,10 +147,10 @@ The API request will look something like this:
 POST /v1/devices/{DEVICE_ID}/led
 
 # EXAMPLE REQUEST IN TERMINAL
-# Core ID is 0123456789abcdef01234567
-# Your access token is 1234123412341234123412341234123412341234
-curl https://api.spark.io/v1/devices/0123456789abcdef01234567/led \
-  -d access_token=1234123412341234123412341234123412341234 \
+# Core ID is 0123456789abcdef
+# Your access token is 123412341234
+curl https://api.spark.io/v1/devices/0123456789abcdef/led \
+  -d access_token=123412341234 \
   -d params=l1,HIGH
 ```
 
@@ -214,10 +214,10 @@ The API request will look something like this:
 GET /v1/devices/{DEVICE_ID}/temperature
 
 # EXAMPLE REQUEST IN TERMINAL
-# Core ID is 0123456789abcdef01234567
-# Your access token is 1234123412341234123412341234123412341234
-curl -G https://api.spark.io/v1/devices/0123456789abcdef01234567/temperature \
-  -d access_token=1234123412341234123412341234123412341234
+# Core ID is 0123456789abcdef
+# Your access token is 123412341234
+curl -G https://api.spark.io/v1/devices/0123456789abcdef/temperature \
+  -d access_token=123412341234
 ```
 
 Local Communication

--- a/src/content/firmware.md
+++ b/src/content/firmware.md
@@ -53,11 +53,11 @@ There are three supported data types:
 
 ```json
 # EXAMPLE REQUEST IN TERMINAL
-# Core ID is 0123456789abcdef01234567
-# Your access token is 1234123412341234123412341234123412341234
-curl "https://api.spark.io/v1/devices/0123456789abcdef01234567/analogvalue?access_token=1234123412341234123412341234123412341234"
-curl "https://api.spark.io/v1/devices/0123456789abcdef01234567/temp?access_token=1234123412341234123412341234123412341234"
-curl "https://api.spark.io/v1/devices/0123456789abcdef01234567/mess?access_token=1234123412341234123412341234123412341234"
+# Core ID is 0123456789abcdef
+# Your access token is 123412341234
+curl "https://api.spark.io/v1/devices/0123456789abcdef/analogvalue?access_token=123412341234"
+curl "https://api.spark.io/v1/devices/0123456789abcdef/temp?access_token=123412341234"
+curl "https://api.spark.io/v1/devices/0123456789abcdef/mess?access_token=123412341234"
 
 # In return you'll get something like this:
 960
@@ -121,8 +121,8 @@ COMPLEMENTARY API CALL
 POST /v1/devices/{DEVICE_ID}/{FUNCTION}
 
 # EXAMPLE REQUEST
-curl https://api.spark.io/v1/devices/0123456789abcdef01234567/brew \
-     -d access_token=1234123412341234123412341234123412341234 \
+curl https://api.spark.io/v1/devices/0123456789abcdef/brew \
+     -d access_token=123412341234 \
      -d "args=coffee"
 ```
 
@@ -214,7 +214,7 @@ curl -H "Authorization: Bearer {ACCESS_TOKEN_GOES_HERE}" \
 
 # Will return a stream that echoes text when your event is published
 event: motion-detected
-data: {"data":"23:23:44","ttl":"60","published_at":"2014-05-28T19:20:34.638Z","coreid":"0123456789abcdef01234567"}
+data: {"data":"23:23:44","ttl":"60","published_at":"2014-05-28T19:20:34.638Z","coreid":"0123456789abcdef"}
 ```
 
 ### Spark.subscribe()

--- a/src/content/shields.md
+++ b/src/content/shields.md
@@ -160,8 +160,8 @@ An example API request to this function would look something like this:
 POST /v1/devices/{DEVICE_ID}/relay
 
 # EXAMPLE REQUEST
-curl https://api.spark.io/v1/devices/0123456789abcdef01234567/relay \
-  -d access_token=1234123412341234123412341234123412341234 -d params=r1,HIGH
+curl https://api.spark.io/v1/devices/0123456789abcdef/relay \
+  -d access_token=123412341234 -d params=r1,HIGH
 ```
 
 **USE EXTREME CAUTION WHEN DEALING WITH HIGH VOLTAGE !!**
@@ -705,7 +705,7 @@ To send API commands:
 
 ```json
 # Sending command to go forward
-curl https://api.spark.io/v1/devices/0123456789abcdef01234567/rccar -d access_token=1234 -d params=rc,FORWARD
+curl https://api.spark.io/v1/devices/0123456789abcdef/rccar -d access_token=123412341234 -d params=rc,FORWARD
 ```
 
 ### Motor Driver Shield Specifications

--- a/src/content/start.md
+++ b/src/content/start.md
@@ -236,10 +236,10 @@ Sets the pin to HIGH or LOW, which either connects it to 3.3V (the maximum volta
     POST /v1/devices/{DEVICE_ID}/digitalwrite
 
     # EXAMPLE REQUEST IN TERMINAL
-    # Core ID is 0123456789abcdef01234567
-    # Your access token is 1234123412341234123412341234123412341234
-    curl https://api.spark.io/v1/devices/0123456789abcdef01234567/digitalwrite \
-      -d access_token=1234123412341234123412341234123412341234 -d params=D0,HIGH
+    # Core ID is 0123456789abcdef
+    # Your access token is 123412341234
+    curl https://api.spark.io/v1/devices/0123456789abcdef/digitalwrite \
+      -d access_token=123412341234 -d params=D0,HIGH
 
 The parameters must be the pin (A0 to A7, D0 to D7), followed by either HIGH or LOW, separated by a comma. The return value will be 1 if the write succeeds, and -1 if it fails.
 
@@ -252,10 +252,10 @@ Sets the pin to a value between 0 and 255, where 0 is the same as LOW and 255 is
     POST /v1/devices/{DEVICE_ID}/analogwrite
 
     # EXAMPLE REQUEST IN TERMINAL
-    # Core ID is 0123456789abcdef01234567
-    # Your access token is 1234123412341234123412341234123412341234
-    curl https://api.spark.io/v1/devices/0123456789abcdef01234567/analogwrite \
-      -d access_token=1234123412341234123412341234123412341234 -d params=A0,215
+    # Core ID is 0123456789abcdef
+    # Your access token is 123412341234
+    curl https://api.spark.io/v1/devices/0123456789abcdef/analogwrite \
+      -d access_token=123412341234 -d params=A0,215
 
 The parameters must be the pin (A0 to A7, D0 to D7), followed by an integer value from 0 to 255, separated by a comma. The return value will be 1 if the write succeeds, and -1 if it fails.
 
@@ -269,10 +269,10 @@ This will read the digital value of a pin, which can be read as either HIGH or L
     POST /v1/devices/{DEVICE_ID}/digitalread
 
     # EXAMPLE REQUEST IN TERMINAL
-    # Core ID is 0123456789abcdef01234567
-    # Your access token is 1234123412341234123412341234123412341234
-    curl https://api.spark.io/v1/devices/0123456789abcdef01234567/digitalread \
-      -d access_token=1234123412341234123412341234123412341234 -d params=D0
+    # Core ID is 0123456789abcdef
+    # Your access token is 123412341234
+    curl https://api.spark.io/v1/devices/0123456789abcdef/digitalread \
+      -d access_token=123412341234 -d params=D0
 
 
 The parameter must be the pin (A0 to A7, D0 to D7). The return value will be 1 if the pin is HIGH, 0 if the pin is LOW, and -1 if the read fails.
@@ -286,10 +286,10 @@ This will read the analog value of a pin, which is a value from 0 to 4095, where
     POST /v1/devices/{DEVICE_ID}/analogread
 
     # EXAMPLE REQUEST IN TERMINAL
-    # Core ID is 0123456789abcdef01234567
-    # Your access token is 1234123412341234123412341234123412341234
-    curl https://api.spark.io/v1/devices/0123456789abcdef01234567/analogread \
-      -d access_token=1234123412341234123412341234123412341234 -d params=A0
+    # Core ID is 0123456789abcdef
+    # Your access token is 123412341234
+    curl https://api.spark.io/v1/devices/0123456789abcdef/analogread \
+      -d access_token=123412341234 -d params=A0
 
 The parameters must be the pin (A0 to A7, D0 to D7). The return value will be between 0 and 4095 if the read succeeds, and -1 if it fails.
 


### PR DESCRIPTION
This should fix #3 and the docs look really ugly now on the right side since the full code cannot be seen due to the length
