### PR TITLE
Corrected "flash --usb" doc

### DIFF
--- a/src/content/cli.md
+++ b/src/content/cli.md
@@ -319,8 +319,8 @@ $ spark flash 0123456789ABCDEFGHI cc3000
 
 # how to flash if your core is blinking yellow and connected over usb
 # requires dfu-util
-$ spark flash 0123456789ABCDEFGHI tinker --usb
-$ spark flash 0123456789ABCDEFGHI cc3000 --usb
+$ spark flash --usb tinker
+$ spark flash --usb cc3000
 ```
 
 


### PR DESCRIPTION
The existing doc for this would complain with the error: 

```
Please specify a firmware file to flash locally to your core
```
