### PR TITLE
The important line which shows the actual use of WiFi.macAddress() added...

### DIFF
--- a/src/content/firmware.md
+++ b/src/content/firmware.md
@@ -1,4 +1,4 @@
----
+﻿---
 word: Firmware
 title: Core code (Firmware)
 order: 3
@@ -559,6 +559,8 @@ byte mac[6];
 void setup() {
   Serial.begin(9600);
   while (!Serial.available()) Spark.process();
+
+  WiFi.macAddress(mac);
 
   Serial.print(mac[5],HEX);
   Serial.print(":");


### PR DESCRIPTION
The current example for WiFi.macAddress() does not contain a call to this very function.
So I tried to add one way to do it.

On the other hand I don't quite get the sense in passing an `byte[6]` in which will receive the mac address and then at the same time returning the pointer to the one array that I just passed in anyway.

If the code was slightly altered, to accept a NULL pointer as input and then allocating a new array and returning this new array, then I'd see more sense in that.

But this is only one oppinion ;-)
