### PR TITLE
Fixed parameter name

### DIFF
--- a/src/content/javascript.md
+++ b/src/content/javascript.md
@@ -50,7 +50,7 @@ Or you can use an existing access token.
 ```javascript
 var spark = require('spark');
 
-spark.login({access_token: 'ACCESS_TOKEN'});
+spark.login({accessToken: 'ACCESS_TOKEN'});
 ```
 
 ## Responses


### PR DESCRIPTION
Parameter which should contain token is named accessToken as in https://github.com/spark/sparkjs/blob/master/lib/spark.js#L181
