### PR TITLE
sparkjs: rename call command to callFunction

### DIFF
--- a/src/content/javascript.md
+++ b/src/content/javascript.md
@@ -213,12 +213,12 @@ Each device has the following parameters:
 
 And you can call the following commands on it:
 
-### call
+### callFunction
 
 Call a function in device
 
 ```javascript
-device.call('brew', 'D0:HIGH', function(err, data) {
+device.callFunction('brew', 'D0:HIGH', function(err, data) {
   if (err) {
     console.log('An error occurred:', err);
   } else {


### PR DESCRIPTION
Rename call command to callFunction command based on spark/sparkjs@f9083b2b
