### PR TITLE
Fix Serial2 inclusion code

### DIFF
--- a/src/content/firmware.md
+++ b/src/content/firmware.md
@@ -879,7 +879,7 @@ Used for communication between the Spark Core and a computer or other devices. T
 
 `Serial1:` This channel is available via the Core's TX and RX pins.
 
-`Serial2:` This channel is optionally available via the Core's D1(TX) and D0(RX) pins. To use Serial2, add `#include "Serial2.h"` near the top of your Spark App's main code file.
+`Serial2:` This channel is optionally available via the Core's D1(TX) and D0(RX) pins. To use Serial2, add `#include "Serial2/Serial2.h"` near the top of your Spark App's main code file.
 
 To use the TX/RX (Serial1) or D1/D0 (Serial2) pins to communicate with your personal computer, you will need an additional USB-to-serial adapter. To use them to communicate with an external TTL serial device, connect the TX pin to your device's RX pin, the RX to your device's TX pin, and the ground of your Core to your device's ground.
 


### PR DESCRIPTION
After reading about Serial2 on the docs I wanted to try it out, but `#include "Serial2.h"` wasn't working. After some digging, I found that the proper way to include it is `#include "Serial2/Serial2.h"` . The documentation doesn't yet reflect this, and thus this commit :)
