### PR TITLE
Show the maximum length of an argument when controlling a device

### DIFF
--- a/src/content/api.md
+++ b/src/content/api.md
@@ -337,6 +337,7 @@ The API request will be routed to the Spark Core and will run your `brew` functi
 ```
 
 All Spark functions take a String as the only argument and must return a 32-bit integer.
+The maximum length of the argument is 63 characters.
 
 
 Reading data from a Core


### PR DESCRIPTION
Also added this indication in the API docs. Thanks to @crtr0 for pointing out the need in https://github.com/spark/sparkjs/issues/33.
