### PR TITLE
Added note about dedicated Spark Dev directory

### DIFF
--- a/src/content/dev.md
+++ b/src/content/dev.md
@@ -61,6 +61,8 @@ Compiling code
 
 ![Compile button]({{assets}}/images/ide-compile.jpg)
 
+Before compiling your project, make sure your project files are in a dedicated directory.  If other files not related to your project are present in the project directory, you may experience errors when trying to compile.
+
 To compile your current project, click on the **Compile in the cloud** button. If your code doesn't contain errors, you'll see a new file named **firmware_X.bin** in your project's directory (where *X* is a timestamp).
 
 ![Compile errors]({{assets}}/images/ide-compile-errors.jpg)

--- a/src/content/dev.md
+++ b/src/content/dev.md
@@ -59,9 +59,9 @@ Then you will see list of all your devices along with an indicator of online sta
 Compiling code
 ---
 
-![Compile button]({{assets}}/images/ide-compile.jpg)
-
 Before compiling your project, make sure your project files are in a dedicated directory.  If other files not related to your project are present in the project directory, you may experience errors when trying to compile.
+
+![Compile button]({{assets}}/images/ide-compile.jpg)
 
 To compile your current project, click on the **Compile in the cloud** button. If your code doesn't contain errors, you'll see a new file named **firmware_X.bin** in your project's directory (where *X* is a timestamp).
 


### PR DESCRIPTION
If code is not in a dedicated directory, the cloud compile functionality in Spark Dev may not work.  Added verbiage to clarify this issue for new users.
