### PR TITLE
Add mention of Spark.function name length truncation

### DIFF
--- a/src/content/api.md
+++ b/src/content/api.md
@@ -272,7 +272,9 @@ Controlling a Core
 --------
 
 To control a Core, you must first define and expose *functions* in the Core firmware.
-You then call these functions remotely using the Spark Cloud API.
+You then call these functions remotely using the Spark Cloud API. 
+
+Note: If you have declared a function name longer than 12 characters it *will be truncated* to 12 characters. Example: Spark.function("someFunction1", ...); exposes a function called **someFunction** and *not* **someFunction1**
 
 ```cpp
 /* FIRMWARE */

--- a/src/content/firmware.md
+++ b/src/content/firmware.md
@@ -80,7 +80,7 @@ Currently the application supports the creation of up to 4 different Spark funct
 
 In order to register a Spark function, the user provides the `funcKey`, which is the string name used to make a POST request and a `funcName`, which is the actual name of the function that gets called in the Spark app. The Spark function can return any integer; `-1` is commonly used for a failed function call.
 
-The length of the `funcKey` is limited to a max of 12 characters.
+The length of the `funcKey` is limited to a max of 12 characters. If you declare a function name longer than 12 characters it will be truncated to 12 characters. Example: Spark.function("someFunction1", ...); exposes a function called someFunction and not someFunction1
 
 A Spark function is set up to take one argument of the [String](http://arduino.cc/en/Reference/StringObject) datatype. This argument length is limited to a max of 63 characters.
 


### PR DESCRIPTION
Adding a mention that function names longer than 12 character will be truncated may clear up issues with users who accidentally declare functions with names longer than 12 characters and then fail to find their functions due to the name truncation which occurs. 
