### PR TITLE
Fixed overflow of code snippets

### DIFF
--- a/src/stylesheets/basics.less
+++ b/src/stylesheets/basics.less
@@ -117,6 +117,9 @@ input {
   font-size: 14px;
   color: #505050;
 }
+pre {
+  overflow: auto;
+}
 pre code {
   color: #fff;
 }


### PR DESCRIPTION
Fixes overflow of code snippets.

<h2>Before:</h2>

![screen shot 2015-01-28 at 5 28 55 pm](https://cloud.githubusercontent.com/assets/8119609/5950765/2f5ae95a-a713-11e4-9daa-dd801e737196.png)

<h2>After:</h2>

![screen shot 2015-01-28 at 5 29 53 pm](https://cloud.githubusercontent.com/assets/8119609/5950776/4be20c3e-a713-11e4-927c-7e8bfb3681b4.png)

<h2>Includes following code</h2>

<i>/docs/src/stylesheets/basics.less</i>

<pre>
pre {
  overflow: auto;
}
</pre>
