### PR TITLE
Correct daylight saving example

### DIFF
--- a/src/content/firmware.md
+++ b/src/content/firmware.md
@@ -2560,7 +2560,7 @@ The Spark Core will remember this offset until reboot.
 
 ```cpp
 // Set time zone to Eastern USA daylight saving time
-Time.zone(-5);
+Time.zone(-4);
 ```
 
 Parameters: floating point offset from UTC in hours, from -12.0 to 13.0


### PR DESCRIPTION
Eastern USA daylight saving is UTC -4

Fixes: https://github.com/spark/docs/issues/310
